### PR TITLE
New checker

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest mypy
+        if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,11 @@
+black==21.9b0
+click==7.1.2
+hypothesis==6.13.12
+mypy==0.910
+mypy-extensions==0.4.3
+pylint==2.11.1
+pytest==6.2.5
+PyYAML==5.4.1
+types-click==7.1.5
+types-PyYAML==5.4.10
+typing-extensions==3.10.0.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,5 @@
 python_version = 3.9
 [mypy-pexpect.*]
 ignore_missing_imports = True
+[mypy-click.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,15 @@
+attrs==21.2.0
 click==7.1.2
-pexpect==4.8.0
-ptyprocess==0.7.0
-PyYAML==5.4.1
 hypothesis==6.13.12
+iniconfig==1.1.1
+packaging==21.0
+pexpect==4.8.0
+pluggy==1.0.0
+ptyprocess==0.7.0
+py==1.10.0
+pyparsing==2.4.7
+pytest==6.2.5
+PyYAML==5.4.1
+runner @ file:///home/tricky/Documents/job/good-bot-runner
+sortedcontainers==2.4.0
+toml==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,5 @@ py==1.10.0
 pyparsing==2.4.7
 pytest==6.2.5
 PyYAML==5.4.1
-runner @ file:///home/tricky/Documents/job/good-bot-runner
 sortedcontainers==2.4.0
 toml==0.10.2

--- a/runner/cli.py
+++ b/runner/cli.py
@@ -73,7 +73,7 @@ def check_config(input: str) -> None:
     parsed = funcmodule.parse_config(DATA_DIR / pathlib.Path(input))
 
     # parse_config does not assume anything about the config file.
-    funcmodule.check_config_no_interaction(parsed)
+    funcmodule.check_parsed_config_no_interaction(parsed)
 
 def main():
     gb_run()

--- a/runner/cli.py
+++ b/runner/cli.py
@@ -70,10 +70,7 @@ def gb_run(input: str) -> None:
 @click.argument("input", type=str)
 def check_config(input: str) -> None:
     """Checks you configuration file to make sure that there are no errors."""
-    parsed = funcmodule.parse_config(DATA_DIR / pathlib.Path(input))
-
-    # parse_config does not assume anything about the config file.
-    funcmodule.check_parsed_config_no_interaction(parsed)
+    funcmodule.check_parsed_config_no_interaction(DATA_DIR / pathlib.Path(input))
 
 def main():
     gb_run()

--- a/runner/cli.py
+++ b/runner/cli.py
@@ -49,6 +49,9 @@ def gb_run(input: str) -> None:
     """
     parsed = funcmodule.parse_config(DATA_DIR / pathlib.Path(input))
 
+    # parse_config does not assume anything about the config file.
+    funcmodule.check_config(parsed)
+
     try:
         commands = parsed["commands"]
         expect = parsed["expect"]

--- a/runner/cli.py
+++ b/runner/cli.py
@@ -66,11 +66,13 @@ def gb_run(input: str) -> None:
 
     return None
 
+
 @click.command()
 @click.argument("input", type=str)
 def check_config(input: str) -> None:
     """Checks you configuration file to make sure that there are no errors."""
     funcmodule.check_parsed_config_no_interaction(DATA_DIR / pathlib.Path(input))
+
 
 def main():
     gb_run()

--- a/runner/cli.py
+++ b/runner/cli.py
@@ -66,6 +66,14 @@ def gb_run(input: str) -> None:
 
     return None
 
+@click.command()
+@click.argument("input", type=str)
+def check_config(input: str) -> None:
+    """Checks you configuration file to make sure that there are no errors."""
+    parsed = funcmodule.parse_config(DATA_DIR / pathlib.Path(input))
+
+    # parse_config does not assume anything about the config file.
+    funcmodule.check_config_no_interaction(parsed)
 
 def main():
     gb_run()

--- a/runner/funcmodule.py
+++ b/runner/funcmodule.py
@@ -102,9 +102,24 @@ def check_config(conf: dict) -> None:
 def check_parsed_config_no_interaction(conf_path: Path) -> None:
     """
     check_parsed_config_no_interaction makes sure that a configuration file
-    is valid.
+    is valid. The configuration file is parsed using ``parse_config()```.
+
+    Once the configuration file is unmarshalled, the result is checked for:
+
+    - type is dict.
+    - No more than two keys.
+    - Keys are `commands` or `expect`.
+
+    Parameters
+    ----------
+    conf_path: pathlib.Path
+        The path towards the configuration file to check. Can be relative
+        or absolute.
     """
-    parsed_config = parse_congfig(conf_path)
+    conf = parse_congfig(conf_path)
+
+    if not isinstance(conf, dict):
+        raise TypeError(f"The configuration file must be seen as a dictionary. Currently seen as {type(conf)}")
 
     if len(conf.keys()) > 2:
         raise KeyError(

--- a/runner/funcmodule.py
+++ b/runner/funcmodule.py
@@ -42,12 +42,6 @@ def parse_config(conf_path: pathlib.Path) -> dict:
 
     parsed = yaml.safe_load(conf)
 
-    if type(parsed) != dict:
-        print("Wrong type of config file.")
-        sys.exit()
-
-    check_config(parsed)
-
     return parsed
 
 def check_config(conf: dict) -> None:
@@ -99,7 +93,7 @@ def check_config(conf: dict) -> None:
                     print("Quitting...")
                     sys.exit()
 
-def check_parsed_config_no_interaction(conf_path: Path) -> None:
+def check_parsed_config_no_interaction(conf_path: pathlib.Path) -> None:
     """
     check_parsed_config_no_interaction makes sure that a configuration file
     is valid. The configuration file is parsed using ``parse_config()```.
@@ -116,7 +110,7 @@ def check_parsed_config_no_interaction(conf_path: Path) -> None:
         The path towards the configuration file to check. Can be relative
         or absolute.
     """
-    conf = parse_congfig(conf_path)
+    conf = parse_config(conf_path)
 
     if not isinstance(conf, dict):
         raise TypeError(f"The configuration file must be seen as a dictionary. Currently seen as {type(conf)}")

--- a/runner/funcmodule.py
+++ b/runner/funcmodule.py
@@ -21,6 +21,34 @@ import pathlib
 import sys
 import yaml
 
+def parse_config(conf_path: pathlib.Path) -> dict:
+    """Parses a config file to generate a dict.
+
+    Should only be used on the files that contain a command.
+    Not to be used on the main conf file.
+
+    Args:
+        conf_path (pathlib.Path): The path to the user's
+        configuration file.
+
+    Returns:
+        dict: A dict that contains info on the command. The
+        keys will either be `commands` or `expect`. Values
+        should be `lists` of shell commands or stuff to
+        expect before running those shell commands.
+    """
+    with open(conf_path, "r") as stream:
+        conf = stream.read()
+
+    parsed = yaml.safe_load(conf)
+
+    if type(parsed) != dict:
+        print("Wrong type of config file.")
+        sys.exit()
+
+    check_config(parsed)
+
+    return parsed
 
 def check_config(conf: dict) -> None:
     """Checks the parsed configuration file for wrong types and arguments.
@@ -71,36 +99,22 @@ def check_config(conf: dict) -> None:
                     print("Quitting...")
                     sys.exit()
 
-
-def parse_config(conf_path: pathlib.Path) -> dict:
-    """Parses a config file to generate a dict.
-
-    Should only be used on the files that contain a command.
-    Not to be used on the main conf file.
-
-    Args:
-        conf_path (pathlib.Path): The path to the user's
-        configuration file.
-
-    Returns:
-        dict: A dict that contains info on the command. The
-        keys will either be `commands` or `expect`. Values
-        should be `lists` of shell commands or stuff to
-        expect before running those shell commands.
+def check_parsed_config_no_interaction(conf_path: Path) -> None:
     """
-    with open(conf_path, "r") as stream:
-        conf = stream.read()
+    check_parsed_config_no_interaction makes sure that a configuration file
+    is valid.
+    """
+    parsed_config = parse_congfig(conf_path)
 
-    parsed = yaml.safe_load(conf)
-
-    if type(parsed) != dict:
-        print("Wrong type of config file.")
-        sys.exit()
-
-    check_config(parsed)
-
-    return parsed
-
+    if len(conf.keys()) > 2:
+        raise KeyError(
+            f"Your configuration file must only have 2 keys, not {len(conf.keys())}"
+        )
+    for key, value in conf.items():
+        if key not in ("commands", "expect"):
+            raise KeyError(
+                "Every key in your configuration file must be either 'commands' or 'expect'."
+            )
 
 #######################################################################
 #                             Debugging                               #

--- a/runner/funcmodule.py
+++ b/runner/funcmodule.py
@@ -21,6 +21,7 @@ import pathlib
 import sys
 import yaml
 
+
 def parse_config(conf_path: pathlib.Path) -> dict:
     """Parses a config file to generate a dict.
 
@@ -44,6 +45,7 @@ def parse_config(conf_path: pathlib.Path) -> dict:
 
     return parsed
 
+
 def check_config(conf: dict) -> None:
     """Checks the parsed configuration file for wrong types and arguments.
 
@@ -62,7 +64,9 @@ def check_config(conf: dict) -> None:
     """
 
     if not isinstance(conf, dict):
-        raise TypeError(f"The configuration file must be seen as a dictionary. Currently seen as {type(conf)}")
+        raise TypeError(
+            f"The configuration file must be seen as a dictionary. Currently seen as {type(conf)}"
+        )
 
     if len(conf.keys()) > 2:
         raise KeyError(
@@ -96,6 +100,7 @@ def check_config(conf: dict) -> None:
                     print("Quitting...")
                     sys.exit()
 
+
 def check_parsed_config_no_interaction(conf_path: pathlib.Path) -> None:
     """
     check_parsed_config_no_interaction makes sure that a configuration file
@@ -116,7 +121,9 @@ def check_parsed_config_no_interaction(conf_path: pathlib.Path) -> None:
     conf = parse_config(conf_path)
 
     if not isinstance(conf, dict):
-        raise TypeError(f"The configuration file must be seen as a dictionary. Currently seen as {type(conf)}")
+        raise TypeError(
+            f"The configuration file must be seen as a dictionary. Currently seen as {type(conf)}"
+        )
 
     if len(conf.keys()) > 2:
         raise KeyError(
@@ -127,6 +134,7 @@ def check_parsed_config_no_interaction(conf_path: pathlib.Path) -> None:
             raise KeyError(
                 "Every key in your configuration file must be either 'commands' or 'expect'."
             )
+
 
 #######################################################################
 #                             Debugging                               #

--- a/runner/funcmodule.py
+++ b/runner/funcmodule.py
@@ -61,6 +61,9 @@ def check_config(conf: dict) -> None:
         KeyError: If a key is named differently than `commands` or `expect`.
     """
 
+    if not isinstance(conf, dict):
+        raise TypeError(f"The configuration file must be seen as a dictionary. Currently seen as {type(conf)}")
+
     if len(conf.keys()) > 2:
         raise KeyError(
             f"Your configuration file must only have 2 keys, not {len(conf.keys())}"

--- a/tests/examples/bad_conf_key_names.yaml
+++ b/tests/examples/bad_conf_key_names.yaml
@@ -1,0 +1,6 @@
+command: # Should be commands
+  - echo 'hello world'
+  - ls
+expects: # Should be expect
+  - prompt
+  - prompt

--- a/tests/examples/bad_conf_keys.yaml
+++ b/tests/examples/bad_conf_keys.yaml
@@ -1,0 +1,7 @@
+commands:
+  - echo 'hello world'
+  - ls
+expect:
+  - prompt
+  - prompt
+read: "Hello, world"

--- a/tests/examples/bad_conf_type.yaml
+++ b/tests/examples/bad_conf_type.yaml
@@ -1,0 +1,2 @@
+- commands: ["echo 'hello world'", "ls -a"]
+- expect: ["prompt", "prompt"]

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 CONFIGPATH = Path("./tests/examples")
 
+
 class TestConfigTest(unittest.TestCase):
     """Testing that the config checker raises the right errors."""
 
@@ -41,8 +42,10 @@ class TestParsing(unittest.TestCase):
             self.assertEqual(type(values), type([]))
             self.assertEqual(type(keys), type(""))
 
+
 class TestNoInteractionChecker(unittest.TestCase):
     """Test for the check_parsed_config_no_interaction function."""
+
     def test_raises_wrong_type(self):
         """
         Passes a file that is seen as a list once unmarshalled.
@@ -50,7 +53,10 @@ class TestNoInteractionChecker(unittest.TestCase):
         See ``good-bot-runner/tests/examples/bad_conf_type.yaml``.
         """
         with self.assertRaises(TypeError):
-            funcmodule.check_parsed_config_no_interaction(CONFIGPATH/ "bad_conf_type.yaml")
+            funcmodule.check_parsed_config_no_interaction(
+                CONFIGPATH / "bad_conf_type.yaml"
+            )
+
     def test_raises_too_many_keys(self):
         """
         This test makes sure that the function will raise an error
@@ -59,7 +65,10 @@ class TestNoInteractionChecker(unittest.TestCase):
         See ``good-bot-runner/tests/examples/bad_conf_keys.yaml``.
         """
         with self.assertRaises(KeyError):
-            funcmodule.check_parsed_config_no_interaction(CONFIGPATH / "bad_conf_keys.yaml")
+            funcmodule.check_parsed_config_no_interaction(
+                CONFIGPATH / "bad_conf_keys.yaml"
+            )
+
     def test_raises_bad_key_name(self):
         """
         Keys in a ``runner`` file can only be named ``commands``
@@ -67,7 +76,10 @@ class TestNoInteractionChecker(unittest.TestCase):
         See ``good-bot-runner/tests/examples/bad_conf_key_names.yaml``.
         """
         with self.assertRaises(KeyError):
-            funcmodule.check_parsed_config_no_interaction(CONFIGPATH / "bad_conf_key_names.yaml")
+            funcmodule.check_parsed_config_no_interaction(
+                CONFIGPATH / "bad_conf_key_names.yaml"
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 CONFIGPATH = Path("./tests/examples")
 
-
 class TestConfigTest(unittest.TestCase):
     """Testing that the config checker raises the right errors."""
 
@@ -42,6 +41,16 @@ class TestParsing(unittest.TestCase):
             self.assertEqual(type(values), type([]))
             self.assertEqual(type(keys), type(""))
 
+class TestNoInteractionChecker(unittest.TestCase):
+    """Test for the check_parsed_config_no_interaction function."""
+    def test_raises_wrong_type(self):
+        """
+        Passes a file that is seen as a list once unmarshalled.
+        This test makes sure that the function will raise an error.
+        See ``good-bot-runner/tests/examples/bad_conf_type.yaml``.
+        """
+        with self.assertRaises(TypeError):
+            funcmodule.check_parsed_config_no_interaction(CONFIGPATH/ "bad_conf_type.yaml")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -51,6 +51,23 @@ class TestNoInteractionChecker(unittest.TestCase):
         """
         with self.assertRaises(TypeError):
             funcmodule.check_parsed_config_no_interaction(CONFIGPATH/ "bad_conf_type.yaml")
+    def test_raises_too_many_keys(self):
+        """
+        This test makes sure that the function will raise an error
+        when an unmarshalled configuration file contains too many
+        keys.
+        See ``good-bot-runner/tests/examples/bad_conf_keys.yaml``.
+        """
+        with self.assertRaises(KeyError):
+            funcmodule.check_parsed_config_no_interaction(CONFIGPATH / "bad_conf_keys.yaml")
+    def test_raises_bad_key_name(self):
+        """
+        Keys in a ``runner`` file can only be named ``commands``
+        or ``expect``. If not, the checker should raise an error.
+        See ``good-bot-runner/tests/examples/bad_conf_key_names.yaml``.
+        """
+        with self.assertRaises(KeyError):
+            funcmodule.check_parsed_config_no_interaction(CONFIGPATH / "bad_conf_key_names.yaml")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
New
------
- ``check_config_no_interaction``
  - A function to check a ``runner`` configuration file without interacting with the user.
  - Can be used from other programs (like ``good-bot``) to check config files before using ``runner``.
- Tests for the new function.
- A CLI command for the new function.

Changes
------------
- Better ``requirements.txt``.
  - It is no longer missing dependencies.
- ``parse_config()`` no longer makes any checks.
  - It was using the interactive ``check_config()`` function, and needed to be used in the new non-interactive function.
  - The checks are now done in the ``cli.py`` module (``check_config()`` has to be called explicitly)